### PR TITLE
Improve CMake presets and dependency configuration

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,2 +1,2 @@
 CompileFlags:
-  CompilationDatabase: build
+  CompilationDatabase: build/debug

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -13,82 +13,41 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
-      # Set fail-fast to false to ensure that feedback is delivered for all matrix combinations. Consider changing this to true when your workflow is stable.
       fail-fast: false
-
-      # Set up a matrix to run the following 3 configurations:
-      # 1. <Windows, Release, latest MSVC compiler toolchain on the default runner image, default generator>
-      # 2. <Linux, Release, latest GCC compiler toolchain on the default runner image, default generator>
-      # 3. <Linux, Release, latest Clang compiler toolchain on the default runner image, default generator>
-      #
-      # To add more build types (Release, Debug, RelWithDebInfo, etc.) customize the build_type list.
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        build_type: [Release]
-        c_compiler: [gcc, clang, cl]
-        
         include:
-          # Windows
           - os: windows-latest
             c_compiler: cl
             cpp_compiler: cl
-          - os: windows-latest
-            c_compiler: gcc
-            cpp_compiler: g++
-          - os: windows-latest
-            c_compiler: clang
-            cpp_compiler: clang++
-
-          # Linux
           - os: ubuntu-latest
             c_compiler: gcc
             cpp_compiler: g++
           - os: ubuntu-latest
             c_compiler: clang
             cpp_compiler: clang++
-
-          # macOS
           - os: macos-latest
             c_compiler: clang
             cpp_compiler: clang++
-
-        exclude:
-          - os: ubuntu-latest
-            c_compiler: cl
-          - os: macos-latest
-            c_compiler: cl
-          - os: macos-latest
-            c_compiler: gcc
 
     steps:
     - uses: actions/checkout@v4
 
-    - name: Set reusable strings
-      # Turn repeated input strings (such as the build output directory) into step outputs. These step outputs can be used throughout the workflow file.
-      id: strings
-      shell: bash
-      run: |
-        echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
+    - name: Setup Ninja
+      uses: seanmiddleditch/gha-setup-ninja@v5
+
+    - name: Setup MSVC environment
+      if: runner.os == 'Windows'
+      uses: ilammy/msvc-dev-cmd@v1
 
     - name: Configure CMake
-      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       run: >
-        cmake -B ${{ steps.strings.outputs.build-output-dir }}
+        cmake --preset release
         -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
         -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
-        -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
-        -DASYNC_LOGGER_RING_BUFFER_PROVIDER=FETCH
-        -DENABLE_TESTS=ON 
-        -DENABLE_EXAMPLE=ON
         -S ${{ github.workspace }}
 
     - name: Build
-      # Build your program with the given configuration. Note that --config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
-      run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config ${{ matrix.build_type }}
+      run: cmake --build --preset release
     
     - name: Test
-      working-directory: ${{ steps.strings.outputs.build-output-dir }}
-      # Execute tests defined by the CMake configuration. Note that --build-config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
-      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest --build-config ${{ matrix.build_type }} --output-on-failure
+      run: ctest --preset release

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -78,7 +78,9 @@ jobs:
         -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
         -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        -DASYNC_LOGGER_RING_BUFFER_PROVIDER=FETCH
         -DENABLE_TESTS=ON 
+        -DENABLE_EXAMPLE=ON
         -S ${{ github.workspace }}
 
     - name: Build
@@ -89,4 +91,4 @@ jobs:
       working-directory: ${{ steps.strings.outputs.build-output-dir }}
       # Execute tests defined by the CMake configuration. Note that --build-config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest --build-config ${{ matrix.build_type }}
+      run: ctest --build-config ${{ matrix.build_type }} --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,28 +17,65 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 
-find_package(ring_buffer QUIET)
+set(ASYNC_LOGGER_RING_BUFFER_VERSION 0.1.0)
+set(ASYNC_LOGGER_RING_BUFFER_PROVIDER
+    "AUTO"
+    CACHE STRING "Dependency provider for ring_buffer: FETCH, PACKAGE, or AUTO")
+set_property(
+  CACHE ASYNC_LOGGER_RING_BUFFER_PROVIDER PROPERTY STRINGS FETCH PACKAGE AUTO)
 
-if(ring_buffer_FOUND)
-  message(STATUS "Found local ring_buffer: using ring_buffer::ring_buffer")
-else()
-  message(STATUS "ring_buffer not found locally; fetching via FetchContent")
-
+if(TARGET ring_buffer::ring_buffer)
+  message(STATUS "Using caller-provided ring_buffer target: ring_buffer::ring_buffer")
+elseif(TARGET ring_buffer)
+  message(STATUS "Using caller-provided ring_buffer target: ring_buffer")
+elseif(ASYNC_LOGGER_RING_BUFFER_PROVIDER STREQUAL "FETCH")
+  message(STATUS "Using ring_buffer provider: FETCH")
   include(FetchContent)
   FetchContent_Declare(
     ring_buffer
     GIT_REPOSITORY https://github.com/HuRuilizhen/ring_buffer.git
-    GIT_TAG v0.1.0)
+    GIT_TAG v${ASYNC_LOGGER_RING_BUFFER_VERSION})
   FetchContent_MakeAvailable(ring_buffer)
+elseif(ASYNC_LOGGER_RING_BUFFER_PROVIDER STREQUAL "PACKAGE")
+  message(STATUS "Using ring_buffer provider: PACKAGE")
+  find_package(ring_buffer ${ASYNC_LOGGER_RING_BUFFER_VERSION} CONFIG REQUIRED)
+elseif(ASYNC_LOGGER_RING_BUFFER_PROVIDER STREQUAL "AUTO")
+  message(STATUS "Using ring_buffer provider: AUTO")
+  find_package(ring_buffer ${ASYNC_LOGGER_RING_BUFFER_VERSION} CONFIG QUIET)
+
+  if(ring_buffer_FOUND)
+    message(STATUS "Found local ring_buffer: using ring_buffer::ring_buffer")
+  else()
+    message(STATUS "ring_buffer package not found; falling back to FetchContent")
+
+    include(FetchContent)
+    FetchContent_Declare(
+      ring_buffer
+      GIT_REPOSITORY https://github.com/HuRuilizhen/ring_buffer.git
+      GIT_TAG v${ASYNC_LOGGER_RING_BUFFER_VERSION})
+    FetchContent_MakeAvailable(ring_buffer)
+  endif()
+else()
+  message(
+    FATAL_ERROR
+      "Invalid ASYNC_LOGGER_RING_BUFFER_PROVIDER='${ASYNC_LOGGER_RING_BUFFER_PROVIDER}'. "
+      "Expected one of: FETCH, PACKAGE, AUTO.")
+endif()
+
+if(TARGET ring_buffer::ring_buffer)
+  set(ASYNC_LOGGER_RING_BUFFER_TARGET ring_buffer::ring_buffer)
+elseif(TARGET ring_buffer)
+  set(ASYNC_LOGGER_RING_BUFFER_TARGET ring_buffer)
+else()
+  message(FATAL_ERROR "ring_buffer target not found after dependency resolution")
 endif()
 
 add_library(async_logger STATIC src/async_logger.cc)
+add_library(async_logger::async_logger ALIAS async_logger)
 target_include_directories(
   async_logger PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
                       $<INSTALL_INTERFACE:include>)
-target_link_libraries(
-  async_logger PUBLIC $<$<BOOL:${ring_buffer_FOUND}>:ring_buffer::ring_buffer>
-                      $<$<NOT:$<BOOL:${ring_buffer_FOUND}>>:ring_buffer>)
+target_link_libraries(async_logger PUBLIC ${ASYNC_LOGGER_RING_BUFFER_TARGET})
 
 option(ENABLE_TESTS "Enable tests" OFF)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.20)
 
 project(
   async_logger

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,12 @@ project(
   VERSION 0.1.0
   LANGUAGES CXX)
 
+if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE
+      Debug
+      CACHE STRING "Build type" FORCE)
+endif()
+
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
@@ -68,8 +74,10 @@ if(ENABLE_EXAMPLE)
   add_executable(async_logger_example examples/async_logger_example.cc)
   add_executable(async_logger_macro_example
                  examples/async_logger_macro_example.cc)
-  add_compile_options(async_logger_example PRIVATE -g)
-  add_compile_options(async_logger_macro_example PRIVATE -g)
+  target_compile_options(
+    async_logger_example PRIVATE $<$<CONFIG:Debug>:-O0 -g>)
+  target_compile_options(
+    async_logger_macro_example PRIVATE $<$<CONFIG:Debug>:-O0 -g>)
   target_link_libraries(async_logger_example PRIVATE async_logger)
   target_link_libraries(async_logger_macro_example PRIVATE async_logger)
 endif(ENABLE_EXAMPLE)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,8 +1,8 @@
 {
-  "version": 3,
+  "version": 2,
   "cmakeMinimumRequired": {
     "major": 3,
-    "minor": 15,
+    "minor": 20,
     "patch": 0
   },
   "configurePresets": [

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,63 @@
+{
+  "version": 3,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 15,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "base",
+      "hidden": true,
+      "generator": "Unix Makefiles",
+      "cacheVariables": {
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+        "ASYNC_LOGGER_RING_BUFFER_PROVIDER": "FETCH",
+        "ENABLE_TESTS": "ON",
+        "ENABLE_EXAMPLE": "ON"
+      }
+    },
+    {
+      "name": "debug",
+      "inherits": "base",
+      "binaryDir": "${sourceDir}/build/debug",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "release",
+      "inherits": "base",
+      "binaryDir": "${sourceDir}/build/release",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "debug",
+      "configurePreset": "debug"
+    },
+    {
+      "name": "release",
+      "configurePreset": "release"
+    }
+  ],
+  "testPresets": [
+    {
+      "name": "debug",
+      "configurePreset": "debug",
+      "output": {
+        "outputOnFailure": true
+      }
+    },
+    {
+      "name": "release",
+      "configurePreset": "release",
+      "output": {
+        "outputOnFailure": true
+      }
+    }
+  ]
+}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -9,7 +9,7 @@
     {
       "name": "base",
       "hidden": true,
-      "generator": "Unix Makefiles",
+      "generator": "Ninja",
       "cacheVariables": {
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
         "ASYNC_LOGGER_RING_BUFFER_PROVIDER": "FETCH",

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Build Status](https://img.shields.io/github/actions/workflow/status/HuRuilizhen/async_logger/cmake-multi-platform.yml?branch=release)
 
-An industrial-grade, asynchronous C++20 logging library built on a high-performance ring buffer. Unit tests and sample usage provided. Designed for easy integration via CMake’s `find_package` or `FetchContent`.
+An industrial-grade, asynchronous C++20 logging library built on a high-performance ring buffer. Unit tests and sample usage provided. Designed for easy integration via CMake's `find_package` or `FetchContent`.
 
 ## Features
 
@@ -18,7 +18,9 @@ An industrial-grade, asynchronous C++20 logging library built on a high-performa
 
 - C++20-compatible compiler  
 - CMake >= 3.15  
-- [`ring_buffer`](https://github.com/HuRuilizhen/ring_buffer) library (headers & CMake config)  
+- Network access for dependency fetching in development mode, or a local
+  [`ring_buffer`](https://github.com/HuRuilizhen/ring_buffer) installation when using the
+  `PACKAGE` provider
 - (Optional) GoogleTest for unit tests
 
 ## Table of Contents
@@ -46,71 +48,98 @@ An industrial-grade, asynchronous C++20 logging library built on a high-performa
 
 ### Configuration
 
-| Option                          | Default | Description                               |
-| ------------------------------- | ------- | ----------------------------------------- |
-| `ENABLE_TESTS`                  | OFF     | Build unit tests (requires GTest)         |
-| `ENABLE_EXAMPLE`                | OFF     | Build examples                            |
-| `CMAKE_EXPORT_COMPILE_COMMANDS` | OFF     | Generate `compile_commands.json` for IDEs |
+| Option                               | Default | Description                                                    |
+| ------------------------------------ | ------- | -------------------------------------------------------------- |
+| `ENABLE_TESTS`                       | OFF     | Build unit tests                                               |
+| `ENABLE_EXAMPLE`                     | OFF     | Build examples                                                 |
+| `CMAKE_EXPORT_COMPILE_COMMANDS`      | OFF     | Generate `compile_commands.json` for IDEs                      |
+| `ASYNC_LOGGER_RING_BUFFER_PROVIDER`  | `AUTO`  | Resolve `ring_buffer` via `FETCH`, `PACKAGE`, or `AUTO`        |
 
 ### Execution
 
 ```bash
-# Default build
-cmake -S . -B build
-cmake --build build
+# Recommended development build
+cmake --preset debug
+cmake --build --preset debug
 
-# Build with tests + examples
-cmake -S . -B build -DENABLE_TESTS=ON -DENABLE_EXAMPLE=ON
-cmake --build build
+# Release build
+cmake --preset release
+cmake --build --preset release
 
-# Install
-sudo cmake --install build
+# Run tests
+ctest --preset debug
+
+# Strictly use an installed ring_buffer package
+cmake -S . -B build/package \
+  -DASYNC_LOGGER_RING_BUFFER_PROVIDER=PACKAGE \
+  -DCMAKE_BUILD_TYPE=Debug
+
+# Try local package first, then fall back to FetchContent
+cmake -S . -B build/auto \
+  -DASYNC_LOGGER_RING_BUFFER_PROVIDER=AUTO \
+  -DCMAKE_BUILD_TYPE=Debug
+
+# Install from a configured build tree
+sudo cmake --install build/release
 ```
 
 ## Running Examples
 
 ```bash
-cd ./build/bin && ./async_logger_example
+./build/debug/bin/async_logger_example
 ```
 
 or 
 
 ```bash
-cd ./build/bin && ./async_logger_macro_example
+./build/debug/bin/async_logger_macro_example
 ```
 
 ## Running Tests
 
 ```bash
-cd ./build && ctest --output-on-failure
+ctest --preset debug
 ```
 
 ## Using the Library
 
 ### Including the Library
 
-Without installation, pull both `ring_buffer` and `async_logger`:
+Without installation, pull `async_logger` via `FetchContent`:
 
 ```cmake
 include(FetchContent)
 
-# 1) ring_buffer dependency (optional)
-FetchContent_Declare(
-  ring_buffer
-  GIT_REPOSITORY https://github.com/HuRuilizhen/ring_buffer.git
-  GIT_TAG        v0.1.0
-)
-# 2) async_logger itself
 FetchContent_Declare(
   async_logger
   GIT_REPOSITORY https://github.com/YourUser/async_logger.git
   GIT_TAG        v0.1.0
 )
 
-FetchContent_MakeAvailable(ring_buffer async_logger)
+FetchContent_MakeAvailable(async_logger)
 
 add_executable(my_app main.cpp)
-target_link_libraries(my_app PRIVATE async_logger)
+target_link_libraries(my_app PRIVATE async_logger::async_logger)
+```
+
+By default, `async_logger` uses `ASYNC_LOGGER_RING_BUFFER_PROVIDER=AUTO`.
+That means it will:
+
+- reuse a `ring_buffer` target already provided by the caller
+- otherwise try `find_package(ring_buffer 0.1.0 CONFIG)`
+- otherwise fall back to `FetchContent`
+
+If you want stricter behavior, set the provider before
+`FetchContent_MakeAvailable(async_logger)`:
+
+```cmake
+set(ASYNC_LOGGER_RING_BUFFER_PROVIDER PACKAGE CACHE STRING "" FORCE)
+```
+
+or
+
+```cmake
+set(ASYNC_LOGGER_RING_BUFFER_PROVIDER FETCH CACHE STRING "" FORCE)
 ```
 
 or after installation:
@@ -214,7 +243,7 @@ int main() {
 If you installed via CMake:
 
 ```bash
-sudo cmake --build build --target uninstall_async_logger
+sudo cmake --build build/release --target uninstall_async_logger
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ An industrial-grade, asynchronous C++20 logging library built on a high-performa
 ## Requirements
 
 - C++20-compatible compiler  
-- CMake >= 3.15  
+- CMake >= 3.20  
 - Network access for dependency fetching in development mode, or a local
   [`ring_buffer`](https://github.com/HuRuilizhen/ring_buffer) installation when using the
   `PACKAGE` provider


### PR DESCRIPTION
## Summary
- make debug example builds explicit and point clangd at the preset build tree
- add debug/release CMake presets for local development
- add ring_buffer provider modes with caller-target reuse and documented defaults
- update README usage docs for presets and dependency providers

## Testing
- cmake --build --preset debug
- ctest --preset debug