### PR TITLE
Fix log formatting edge cases

### DIFF
--- a/include/async_logger/async_logger_macro.h
+++ b/include/async_logger/async_logger_macro.h
@@ -1,8 +1,25 @@
 #pragma once
 
 #include <format>
+#include <string>
+#include <string_view>
+#include <utility>
 
 #include "async_logger/async_logger.h"
+
+namespace AsyncLogger::Detail {
+
+inline std::string formatLogMessage(std::string_view msg) {
+  return std::string(msg);
+}
+
+template <typename... Args>
+inline std::string formatLogMessage(std::format_string<Args...> fmt,
+                                    Args&&... args) {
+  return std::format(fmt, std::forward<Args>(args)...);
+}
+
+}  // namespace AsyncLogger::Detail
 
 #define LOG_DEBUG(msg) AsyncLogger::Logger::debug(msg)
 #define LOG_INFO(msg) AsyncLogger::Logger::info(msg)
@@ -10,13 +27,13 @@
 #define LOG_ERROR(msg) AsyncLogger::Logger::error(msg)
 #define LOG_FATAL(msg) AsyncLogger::Logger::fatal(msg)
 
-#define LOGF_DEBUG(fmt, ...) \
-  AsyncLogger::Logger::debug(std::format(fmt __VA_OPT__(, ) __VA_ARGS__))
-#define LOGF_INFO(fmt, ...) \
-  AsyncLogger::Logger::info(std::format(fmt __VA_OPT__(, ) __VA_ARGS__))
-#define LOGF_WARN(fmt, ...) \
-  AsyncLogger::Logger::warn(std::format(fmt __VA_OPT__(, ) __VA_ARGS__))
-#define LOGF_ERROR(fmt, ...) \
-  AsyncLogger::Logger::error(std::format(fmt __VA_OPT__(, ) __VA_ARGS__))
-#define LOGF_FATAL(fmt, ...) \
-  AsyncLogger::Logger::fatal(std::format(fmt __VA_OPT__(, ) __VA_ARGS__))
+#define LOGF_DEBUG(...) \
+  AsyncLogger::Logger::debug(AsyncLogger::Detail::formatLogMessage(__VA_ARGS__))
+#define LOGF_INFO(...) \
+  AsyncLogger::Logger::info(AsyncLogger::Detail::formatLogMessage(__VA_ARGS__))
+#define LOGF_WARN(...) \
+  AsyncLogger::Logger::warn(AsyncLogger::Detail::formatLogMessage(__VA_ARGS__))
+#define LOGF_ERROR(...) \
+  AsyncLogger::Logger::error(AsyncLogger::Detail::formatLogMessage(__VA_ARGS__))
+#define LOGF_FATAL(...) \
+  AsyncLogger::Logger::fatal(AsyncLogger::Detail::formatLogMessage(__VA_ARGS__))

--- a/include/async_logger/async_logger_macro.h
+++ b/include/async_logger/async_logger_macro.h
@@ -11,12 +11,12 @@
 #define LOG_FATAL(msg) AsyncLogger::Logger::fatal(msg)
 
 #define LOGF_DEBUG(fmt, ...) \
-  AsyncLogger::Logger::debug(std::format(fmt, __VA_ARGS__))
+  AsyncLogger::Logger::debug(std::format(fmt __VA_OPT__(, ) __VA_ARGS__))
 #define LOGF_INFO(fmt, ...) \
-  AsyncLogger::Logger::info(std::format(fmt, __VA_ARGS__))
+  AsyncLogger::Logger::info(std::format(fmt __VA_OPT__(, ) __VA_ARGS__))
 #define LOGF_WARN(fmt, ...) \
-  AsyncLogger::Logger::warn(std::format(fmt, __VA_ARGS__))
+  AsyncLogger::Logger::warn(std::format(fmt __VA_OPT__(, ) __VA_ARGS__))
 #define LOGF_ERROR(fmt, ...) \
-  AsyncLogger::Logger::error(std::format(fmt, __VA_ARGS__))
+  AsyncLogger::Logger::error(std::format(fmt __VA_OPT__(, ) __VA_ARGS__))
 #define LOGF_FATAL(fmt, ...) \
-  AsyncLogger::Logger::fatal(std::format(fmt, __VA_ARGS__))
+  AsyncLogger::Logger::fatal(std::format(fmt __VA_OPT__(, ) __VA_ARGS__))

--- a/src/async_logger.cc
+++ b/src/async_logger.cc
@@ -231,9 +231,9 @@ std::string Logger::format(const Entry& entry, bool colored) {
   std::strftime(time_buf, sizeof(time_buf), "%Y-%m-%d %H:%M:%S", &tm);
 
   std::ostringstream oss;
-  if (flag_ & colored) oss << LoggerUtils::getLevelColor(entry.lvl);
+  if (colored) oss << LoggerUtils::getLevelColor(entry.lvl);
   oss << "[" << LoggerUtils::getLevelString(entry.lvl) << "]";
-  if (flag_ & colored) oss << AnsiColor::RESET;
+  if (colored) oss << AnsiColor::RESET;
   oss << " [" << time_buf << "] ";
   oss << "[" << LoggerUtils::getFilenameInPath(entry.loc.file_name()) << ":"
       << entry.loc.line() << "] ";

--- a/tests/async_logger_file_test.cc
+++ b/tests/async_logger_file_test.cc
@@ -118,3 +118,20 @@ TEST(AsyncLogger, FormattedMacroSupportsLiteralOnly) {
   EXPECT_NE(content.find("literal only"), std::string::npos);
   std::remove(TMPLOG.c_str());
 }
+
+TEST(AsyncLogger, FileOutputNeverContainsAnsiColorCodes) {
+  AsyncLogger::Config config;
+  config.level = AsyncLogger::Level::Info;
+  config.flag = AsyncLogger::OutstreamFlag::out_file |
+                AsyncLogger::OutstreamFlag::out_color;
+  config.filename = TMPLOG;
+
+  AsyncLogger::Logger::init(config);
+  AsyncLogger::Logger::error("plain file output");
+  AsyncLogger::Logger::shutdown();
+
+  std::string content = readFile(TMPLOG);
+  EXPECT_NE(content.find("plain file output"), std::string::npos);
+  EXPECT_EQ(content.find("\033["), std::string::npos);
+  std::remove(TMPLOG.c_str());
+}

--- a/tests/async_logger_file_test.cc
+++ b/tests/async_logger_file_test.cc
@@ -1,10 +1,12 @@
 #include <gtest/gtest.h>
 
 #include <ctime>
+#include <fstream>
 #include <string>
 #include <thread>
 
 #include "async_logger/async_logger.h"
+#include "async_logger/async_logger_macro.h"
 
 namespace {
 static const std::string TMPLOG = "test.log";
@@ -100,4 +102,19 @@ TEST(AsyncLogger, LogFileRotation) {
   content = readFile(filename);
   EXPECT_NE(content.find("beta"), std::string::npos);
   std::remove(filename.c_str());
+}
+
+TEST(AsyncLogger, FormattedMacroSupportsLiteralOnly) {
+  AsyncLogger::Config config;
+  config.level = AsyncLogger::Level::Info;
+  config.flag = AsyncLogger::OutstreamFlag::out_file;
+  config.filename = TMPLOG;
+
+  AsyncLogger::Logger::init(config);
+  LOGF_INFO("literal only");
+  AsyncLogger::Logger::shutdown();
+
+  std::string content = readFile(TMPLOG);
+  EXPECT_NE(content.find("literal only"), std::string::npos);
+  std::remove(TMPLOG.c_str());
 }


### PR DESCRIPTION
## Summary
- allow formatted logging macros to compile when called without additional arguments
- make log formatting honor the explicit color toggle instead of rechecking flags implicitly
- add public-interface regression tests for both behaviors

## Testing
- cmake --build --preset debug
- ctest --preset debug --output-on-failure