### PR TITLE
Make file-open failures library-friendly and reorganize tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,12 +95,16 @@ if(ENABLE_TESTS)
   enable_testing()
 
   add_executable(async_logger_basic_test tests/async_logger_basic_test.cc)
+  add_executable(async_logger_error_test tests/async_logger_error_test.cc)
   add_executable(async_logger_file_test tests/async_logger_file_test.cc)
   target_link_libraries(async_logger_basic_test PRIVATE async_logger
+                                                        GTest::gtest_main)
+  target_link_libraries(async_logger_error_test PRIVATE async_logger
                                                         GTest::gtest_main)
   target_link_libraries(async_logger_file_test PRIVATE async_logger
                                                        GTest::gtest_main)
   add_test(NAME async_logger_basic_test COMMAND async_logger_basic_test)
+  add_test(NAME async_logger_error_test COMMAND async_logger_error_test)
   add_test(NAME async_logger_file_test COMMAND async_logger_file_test)
 endif(ENABLE_TESTS)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,15 +97,19 @@ if(ENABLE_TESTS)
   add_executable(async_logger_basic_test tests/async_logger_basic_test.cc)
   add_executable(async_logger_error_test tests/async_logger_error_test.cc)
   add_executable(async_logger_file_test tests/async_logger_file_test.cc)
+  add_executable(async_logger_macro_test tests/async_logger_macro_test.cc)
   target_link_libraries(async_logger_basic_test PRIVATE async_logger
                                                         GTest::gtest_main)
   target_link_libraries(async_logger_error_test PRIVATE async_logger
                                                         GTest::gtest_main)
   target_link_libraries(async_logger_file_test PRIVATE async_logger
                                                        GTest::gtest_main)
+  target_link_libraries(async_logger_macro_test PRIVATE async_logger
+                                                        GTest::gtest_main)
   add_test(NAME async_logger_basic_test COMMAND async_logger_basic_test)
   add_test(NAME async_logger_error_test COMMAND async_logger_error_test)
   add_test(NAME async_logger_file_test COMMAND async_logger_file_test)
+  add_test(NAME async_logger_macro_test COMMAND async_logger_macro_test)
 endif(ENABLE_TESTS)
 
 option(ENABLE_EXAMPLE "Enable example" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,11 +21,12 @@ set(ASYNC_LOGGER_RING_BUFFER_VERSION 0.1.0)
 set(ASYNC_LOGGER_RING_BUFFER_PROVIDER
     "AUTO"
     CACHE STRING "Dependency provider for ring_buffer: FETCH, PACKAGE, or AUTO")
-set_property(
-  CACHE ASYNC_LOGGER_RING_BUFFER_PROVIDER PROPERTY STRINGS FETCH PACKAGE AUTO)
+set_property(CACHE ASYNC_LOGGER_RING_BUFFER_PROVIDER PROPERTY STRINGS FETCH
+                                                              PACKAGE AUTO)
 
 if(TARGET ring_buffer::ring_buffer)
-  message(STATUS "Using caller-provided ring_buffer target: ring_buffer::ring_buffer")
+  message(
+    STATUS "Using caller-provided ring_buffer target: ring_buffer::ring_buffer")
 elseif(TARGET ring_buffer)
   message(STATUS "Using caller-provided ring_buffer target: ring_buffer")
 elseif(ASYNC_LOGGER_RING_BUFFER_PROVIDER STREQUAL "FETCH")
@@ -46,7 +47,8 @@ elseif(ASYNC_LOGGER_RING_BUFFER_PROVIDER STREQUAL "AUTO")
   if(ring_buffer_FOUND)
     message(STATUS "Found local ring_buffer: using ring_buffer::ring_buffer")
   else()
-    message(STATUS "ring_buffer package not found; falling back to FetchContent")
+    message(
+      STATUS "ring_buffer package not found; falling back to FetchContent")
 
     include(FetchContent)
     FetchContent_Declare(
@@ -67,7 +69,8 @@ if(TARGET ring_buffer::ring_buffer)
 elseif(TARGET ring_buffer)
   set(ASYNC_LOGGER_RING_BUFFER_TARGET ring_buffer)
 else()
-  message(FATAL_ERROR "ring_buffer target not found after dependency resolution")
+  message(
+    FATAL_ERROR "ring_buffer target not found after dependency resolution")
 endif()
 
 add_library(async_logger STATIC src/async_logger.cc)
@@ -119,10 +122,9 @@ if(ENABLE_EXAMPLE)
   add_executable(async_logger_example examples/async_logger_example.cc)
   add_executable(async_logger_macro_example
                  examples/async_logger_macro_example.cc)
-  target_compile_options(
-    async_logger_example PRIVATE $<$<CONFIG:Debug>:-O0 -g>)
-  target_compile_options(
-    async_logger_macro_example PRIVATE $<$<CONFIG:Debug>:-O0 -g>)
+  target_compile_options(async_logger_example PRIVATE $<$<CONFIG:Debug>:-O0 -g>)
+  target_compile_options(async_logger_macro_example
+                         PRIVATE $<$<CONFIG:Debug>:-O0 -g>)
   target_link_libraries(async_logger_example PRIVATE async_logger)
   target_link_libraries(async_logger_macro_example PRIVATE async_logger)
 endif(ENABLE_EXAMPLE)

--- a/include/async_logger/async_logger.h
+++ b/include/async_logger/async_logger.h
@@ -6,6 +6,7 @@
 #include <fstream>
 #include <mutex>
 #include <source_location>
+#include <stdexcept>
 #include <string>
 #include <thread>
 
@@ -34,6 +35,11 @@ struct Entry {
   Level lvl = Level::Info;
   std::source_location loc;
   std::string msg;
+};
+
+class FileOpenError : public std::runtime_error {
+ public:
+  explicit FileOpenError(const std::string& filename);
 };
 
 class Logger {

--- a/src/async_logger.cc
+++ b/src/async_logger.cc
@@ -9,6 +9,7 @@
 #include <ostream>
 #include <source_location>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 #include <string_view>
 #include <thread>
@@ -26,6 +27,19 @@ inline constexpr std::string_view BG_RED = "\033[41m";
 }  // namespace AsyncLogger::AnsiColor
 
 namespace AsyncLogger {
+
+namespace {
+
+void openFileOrThrow(std::ofstream& stream, const std::string& filename,
+                     std::ios::openmode mode) {
+  stream.open(filename.c_str(), mode);
+  if (!stream.is_open()) throw FileOpenError(filename);
+}
+
+}  // namespace
+
+FileOpenError::FileOpenError(const std::string& filename)
+    : std::runtime_error("Failed to open file: " + filename) {}
 
 const std::string_view LoggerUtils::getLevelString(Level lvl) {
   switch (lvl) {
@@ -104,11 +118,7 @@ const bool LoggerUtils::tryUpdateFileStream(Logger& lg) {
   if (tryUpdateTimestamp(lg)) {
     lg.ofstream_.flush();
     lg.ofstream_.close();
-    lg.ofstream_.open(getDefaultFilename(), lg.file_mode_);
-    if (!lg.ofstream_.is_open()) {
-      std::cerr << "Failed to open file: " << getDefaultFilename() << std::endl;
-      exit(1);
-    }
+    openFileOrThrow(lg.ofstream_, getDefaultFilename(), lg.file_mode_);
   }
   return false;
 }
@@ -139,11 +149,7 @@ void Logger::loadConfig(const Config& config) {
       filename = config.filename;
     }
 
-    ofstream_.open(filename.c_str(), file_mode_);
-    if (!ofstream_.is_open()) {
-      std::cerr << "Failed to open file: " << filename << std::endl;
-      exit(1);
-    }
+    openFileOrThrow(ofstream_, filename, file_mode_);
   }
 }
 

--- a/tests/async_logger_basic_test.cc
+++ b/tests/async_logger_basic_test.cc
@@ -4,24 +4,14 @@
 #include <string>
 
 #include "async_logger/async_logger.h"
-
-namespace {
-static const std::string TMPLOG = "test.log";
-
-std::string readFile(const std::string& filename) {
-  std::ifstream ifs(filename);
-  std::string content((std::istreambuf_iterator<char>(ifs)),
-                      std::istreambuf_iterator<char>());
-  return content;
-}
-}  // namespace
+#include "async_logger_test_utils.h"
 
 TEST(AsyncLogger, LevelFiltering) {
   // Init with level WARN, debug/info should be filtered out
   AsyncLogger::Config config;
   config.level = AsyncLogger::Level::Warn;
   config.flag = AsyncLogger::OutstreamFlag::out_file;
-  config.filename = TMPLOG;
+  config.filename = AsyncLoggerTest::kTempLog;
 
   AsyncLogger::Logger::init(config);
   AsyncLogger::Logger::debug("debug message");
@@ -30,19 +20,19 @@ TEST(AsyncLogger, LevelFiltering) {
   AsyncLogger::Logger::error("error message");
   AsyncLogger::Logger::shutdown();
 
-  std::string content = readFile(TMPLOG);
+  std::string content = AsyncLoggerTest::readFile(AsyncLoggerTest::kTempLog);
   EXPECT_EQ(content.find("debug message"), std::string::npos);
   EXPECT_EQ(content.find("info message"), std::string::npos);
   EXPECT_NE(content.find("warn message"), std::string::npos);
   EXPECT_NE(content.find("error message"), std::string::npos);
-  std::remove(TMPLOG.c_str());
+  std::remove(AsyncLoggerTest::kTempLog.c_str());
 }
 
 TEST(AsyncLogger, ThreadSafety) {
   AsyncLogger::Config config;
   config.level = AsyncLogger::Level::Info;
   config.flag = AsyncLogger::OutstreamFlag::out_file;
-  config.filename = TMPLOG;
+  config.filename = AsyncLoggerTest::kTempLog;
 
   AsyncLogger::Logger::init(config);
 
@@ -55,9 +45,9 @@ TEST(AsyncLogger, ThreadSafety) {
   for (auto& th : threads) th.join();
   AsyncLogger::Logger::shutdown();
 
-  std::string content = readFile(TMPLOG);
+  std::string content = AsyncLoggerTest::readFile(AsyncLoggerTest::kTempLog);
   for (int i = 0; i < 5; ++i) {
     EXPECT_NE(content.find("thread " + std::to_string(i)), std::string::npos);
   }
-  std::remove(TMPLOG.c_str());
+  std::remove(AsyncLoggerTest::kTempLog.c_str());
 }

--- a/tests/async_logger_error_test.cc
+++ b/tests/async_logger_error_test.cc
@@ -1,0 +1,21 @@
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "async_logger/async_logger.h"
+
+TEST(AsyncLogger, InvalidLogFilePathThrowsException) {
+  AsyncLogger::Config config;
+  config.level = AsyncLogger::Level::Info;
+  config.flag = AsyncLogger::OutstreamFlag::out_file;
+  config.filename = "missing_dir/test.log";
+
+  try {
+    AsyncLogger::Logger::init(config);
+    FAIL() << "Expected FileOpenError to be thrown";
+  } catch (const AsyncLogger::FileOpenError& ex) {
+    EXPECT_NE(std::string(ex.what()).find(config.filename), std::string::npos);
+  }
+
+  AsyncLogger::Logger::shutdown();
+}

--- a/tests/async_logger_file_test.cc
+++ b/tests/async_logger_file_test.cc
@@ -1,23 +1,13 @@
 #include <gtest/gtest.h>
 
 #include <ctime>
-#include <fstream>
 #include <string>
 #include <thread>
 
 #include "async_logger/async_logger.h"
-#include "async_logger/async_logger_macro.h"
+#include "async_logger_test_utils.h"
 
 namespace {
-static const std::string TMPLOG = "test.log";
-
-std::string readFile(const std::string& filename) {
-  std::ifstream ifs(filename);
-  std::string content((std::istreambuf_iterator<char>(ifs)),
-                      std::istreambuf_iterator<char>());
-  return content;
-}
-
 const std::tm newTimeFunc() {
   std::tm time = AsyncLogger::LoggerUtils::getCurrentTime();
   time.tm_mday += 1;
@@ -34,7 +24,7 @@ TEST(AsyncLogger, EmptyFileName) {
   char filename[20];
   std::strftime(filename, sizeof(filename), "%Y-%m-%d.log", &tm);
 
-  std::string content = readFile(filename);
+  std::string content = AsyncLoggerTest::readFile(filename);
   EXPECT_NE(content.find("test"), std::string::npos);
 
   std::remove(filename);
@@ -46,7 +36,7 @@ TEST(AsyncLogger, AppendFileMode) {
   config.level = AsyncLogger::Level::Info;
   config.flag = AsyncLogger::OutstreamFlag::out_file |
                 AsyncLogger::OutstreamFlag::mode_append;
-  config.filename = TMPLOG;
+  config.filename = AsyncLoggerTest::kTempLog;
 
   AsyncLogger::Logger::init(config);
   AsyncLogger::Logger::info("alpha");
@@ -56,19 +46,19 @@ TEST(AsyncLogger, AppendFileMode) {
   AsyncLogger::Logger::info("beta");
   AsyncLogger::Logger::shutdown();
 
-  std::string content = readFile(TMPLOG);
+  std::string content = AsyncLoggerTest::readFile(AsyncLoggerTest::kTempLog);
   EXPECT_NE(content.find("alpha"), std::string::npos);
   EXPECT_NE(content.find("beta"), std::string::npos);
 
-  std::remove(TMPLOG.c_str());
+  std::remove(AsyncLoggerTest::kTempLog.c_str());
 }
 
 TEST(AsyncLogger, TruncFileMode) {
-  // Init with mode append
+  // Init with mode trunc
   AsyncLogger::Config config;
   config.level = AsyncLogger::Level::Info;
   config.flag = AsyncLogger::OutstreamFlag::out_file;
-  config.filename = TMPLOG;
+  config.filename = AsyncLoggerTest::kTempLog;
 
   AsyncLogger::Logger::init(config);
   AsyncLogger::Logger::info("alpha");
@@ -78,11 +68,11 @@ TEST(AsyncLogger, TruncFileMode) {
   AsyncLogger::Logger::info("beta");
   AsyncLogger::Logger::shutdown();
 
-  std::string content = readFile(TMPLOG);
+  std::string content = AsyncLoggerTest::readFile(AsyncLoggerTest::kTempLog);
   EXPECT_EQ(content.find("alpha"), std::string::npos);
   EXPECT_NE(content.find("beta"), std::string::npos);
 
-  std::remove(TMPLOG.c_str());
+  std::remove(AsyncLoggerTest::kTempLog.c_str());
 }
 
 TEST(AsyncLogger, LogFileRotation) {
@@ -90,7 +80,7 @@ TEST(AsyncLogger, LogFileRotation) {
   std::this_thread::sleep_for(std::chrono::milliseconds(500));
 
   std::string filename = AsyncLogger::LoggerUtils::getDefaultFilename();
-  std::string content = readFile(filename);
+  std::string content = AsyncLoggerTest::readFile(filename);
   EXPECT_NE(content.find("alpha"), std::string::npos);
   std::remove(filename.c_str());
 
@@ -99,24 +89,9 @@ TEST(AsyncLogger, LogFileRotation) {
   AsyncLogger::Logger::shutdown();
 
   filename = AsyncLogger::LoggerUtils::getDefaultFilename();
-  content = readFile(filename);
+  content = AsyncLoggerTest::readFile(filename);
   EXPECT_NE(content.find("beta"), std::string::npos);
   std::remove(filename.c_str());
-}
-
-TEST(AsyncLogger, FormattedMacroSupportsLiteralOnly) {
-  AsyncLogger::Config config;
-  config.level = AsyncLogger::Level::Info;
-  config.flag = AsyncLogger::OutstreamFlag::out_file;
-  config.filename = TMPLOG;
-
-  AsyncLogger::Logger::init(config);
-  LOGF_INFO("literal only");
-  AsyncLogger::Logger::shutdown();
-
-  std::string content = readFile(TMPLOG);
-  EXPECT_NE(content.find("literal only"), std::string::npos);
-  std::remove(TMPLOG.c_str());
 }
 
 TEST(AsyncLogger, FileOutputNeverContainsAnsiColorCodes) {
@@ -124,14 +99,14 @@ TEST(AsyncLogger, FileOutputNeverContainsAnsiColorCodes) {
   config.level = AsyncLogger::Level::Info;
   config.flag = AsyncLogger::OutstreamFlag::out_file |
                 AsyncLogger::OutstreamFlag::out_color;
-  config.filename = TMPLOG;
+  config.filename = AsyncLoggerTest::kTempLog;
 
   AsyncLogger::Logger::init(config);
   AsyncLogger::Logger::error("plain file output");
   AsyncLogger::Logger::shutdown();
 
-  std::string content = readFile(TMPLOG);
+  std::string content = AsyncLoggerTest::readFile(AsyncLoggerTest::kTempLog);
   EXPECT_NE(content.find("plain file output"), std::string::npos);
   EXPECT_EQ(content.find("\033["), std::string::npos);
-  std::remove(TMPLOG.c_str());
+  std::remove(AsyncLoggerTest::kTempLog.c_str());
 }

--- a/tests/async_logger_macro_test.cc
+++ b/tests/async_logger_macro_test.cc
@@ -1,0 +1,21 @@
+#include "async_logger/async_logger_macro.h"
+
+#include <gtest/gtest.h>
+
+#include "async_logger/async_logger.h"
+#include "async_logger_test_utils.h"
+
+TEST(AsyncLogger, FormattedMacroSupportsLiteralOnly) {
+  AsyncLogger::Config config;
+  config.level = AsyncLogger::Level::Info;
+  config.flag = AsyncLogger::OutstreamFlag::out_file;
+  config.filename = AsyncLoggerTest::kTempLog;
+
+  AsyncLogger::Logger::init(config);
+  LOGF_INFO("literal only");
+  AsyncLogger::Logger::shutdown();
+
+  std::string content = AsyncLoggerTest::readFile(AsyncLoggerTest::kTempLog);
+  EXPECT_NE(content.find("literal only"), std::string::npos);
+  std::remove(AsyncLoggerTest::kTempLog.c_str());
+}

--- a/tests/async_logger_test_utils.h
+++ b/tests/async_logger_test_utils.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <fstream>
+#include <iterator>
+#include <string>
+
+namespace AsyncLoggerTest {
+
+inline const std::string kTempLog = "test.log";
+
+inline std::string readFile(const std::string& filename) {
+  std::ifstream ifs(filename);
+  return std::string((std::istreambuf_iterator<char>(ifs)),
+                     std::istreambuf_iterator<char>());
+}
+
+}  // namespace AsyncLoggerTest


### PR DESCRIPTION
## Summary
- replace `exit(1)` on log file open failures with a library-friendly `AsyncLogger::FileOpenError`
- add a public regression test covering invalid log file paths
- split the logger test suite by concern so basic, file, macro, and error cases are isolated

## Why
The logger previously terminated the entire host process when it could not open a file. That behavior is fine for an application, but not for a reusable library. Callers need a recoverable failure mode.

The test suite had also become crowded in the file-focused test target, which made responsibilities less clear and made future additions noisier.

## Impact
Consumers now get an exception they can catch instead of an unconditional process exit. The tests are organized into narrower executables, which makes failures easier to localize.

## Validation
- `cmake --build --preset debug`
- `ctest --preset debug -VV`
