### PR TITLE
Capture enqueue timestamps and add configurable worker wait strategies

### DIFF
--- a/include/async_logger/async_logger.h
+++ b/include/async_logger/async_logger.h
@@ -3,6 +3,8 @@
 #include <ring_buffer/mpsc_ring_buffer.h>
 
 #include <atomic>
+#include <condition_variable>
+#include <ctime>
 #include <fstream>
 #include <mutex>
 #include <source_location>
@@ -14,6 +16,8 @@ namespace AsyncLogger {
 
 // Supported log levels
 enum class Level { Debug, Info, Warn, Error, Fatal };
+
+enum class WaitStrategy { Blocking, Yielding };
 
 // Supported ostream control flag
 enum OutstreamFlag {
@@ -29,10 +33,12 @@ struct Config {
   int flag = OutstreamFlag::out_stdout | OutstreamFlag::out_file |
              OutstreamFlag::out_color | OutstreamFlag::mode_append;
   Level level = Level::Info;
+  WaitStrategy wait_strategy = WaitStrategy::Blocking;
 };
 
 struct Entry {
   Level lvl = Level::Info;
+  std::tm timestamp{};
   std::source_location loc;
   std::string msg;
 };
@@ -75,6 +81,9 @@ class Logger {
                const std::string& msg);
   void log(const Entry& entry);
   std::string format(const Entry& entry, bool colored = false);
+  void notifyWorkerForEnqueuedEntry();
+  void markEntryDequeued();
+  void waitForWork();
   static Logger& instance();
 
   // Initialize private method
@@ -90,11 +99,15 @@ class Logger {
   bool need_rotation_{};
   std::tm time_stamp_{};
   std::ofstream ofstream_{};
+  WaitStrategy wait_strategy_{WaitStrategy::Blocking};
 
   // Ring buffer for storing log entries
   RingBuffer::MPSCRingBuffer<Entry> buffer_{1024};
+  size_t queued_entries_{0};
 
   // Thread and state related
+  std::condition_variable work_ready_cv_;
+  std::mutex work_ready_mutex_;
   std::thread worker_;
   std::atomic<bool> running_{false};
 

--- a/src/async_logger.cc
+++ b/src/async_logger.cc
@@ -2,6 +2,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <condition_variable>
 #include <ctime>
 #include <fstream>
 #include <iostream>
@@ -132,6 +133,8 @@ constexpr std::string_view LoggerUtils::getFilenameInPath(
 void Logger::loadConfig(const Config& config) {
   level_.store(config.level, std::memory_order_relaxed);
   flag_ = config.flag;
+  wait_strategy_ = config.wait_strategy;
+  need_rotation_ = false;
 
   if (config.flag & OutstreamFlag::out_file) {
     file_mode_ = std::ios::out;
@@ -158,6 +161,10 @@ void Logger::init(const Config& config) {
   std::lock_guard<std::mutex> lock(lg.init_mutex_);
   if (lg.has_init_.load(std::memory_order_relaxed)) return;
 
+  {
+    std::lock_guard<std::mutex> work_lock(lg.work_ready_mutex_);
+    lg.queued_entries_ = 0;
+  }
   lg.loadConfig(config);
 
   lg.running_ = true;
@@ -181,6 +188,7 @@ void Logger::ensureInit() {
 void Logger::shutdown() {
   auto& lg = instance();
   lg.running_ = false;
+  lg.work_ready_cv_.notify_all();
   if (lg.worker_.joinable()) lg.worker_.join();
   if (lg.ofstream_.is_open()) {
     lg.ofstream_.flush();
@@ -228,13 +236,14 @@ Logger::~Logger() {
 void Logger::enqueue(Level lvl, const std::source_location& loc,
                      const std::string& msg) {
   if (lvl < level_.load(std::memory_order_relaxed)) return;
-  buffer_.tryPush({lvl, loc, msg});
+  if (buffer_.tryPush({lvl, LoggerUtils::timeFuncPtr(), loc, msg}))
+    notifyWorkerForEnqueuedEntry();
 }
 
 std::string Logger::format(const Entry& entry, bool colored) {
-  std::tm tm = LoggerUtils::timeFuncPtr();
   char time_buf[20];
-  std::strftime(time_buf, sizeof(time_buf), "%Y-%m-%d %H:%M:%S", &tm);
+  std::strftime(time_buf, sizeof(time_buf), "%Y-%m-%d %H:%M:%S",
+                &entry.timestamp);
 
   std::ostringstream oss;
   if (colored) oss << LoggerUtils::getLevelColor(entry.lvl);
@@ -258,16 +267,52 @@ void Logger::log(const Entry& entry) {
   }
 }
 
+void Logger::notifyWorkerForEnqueuedEntry() {
+  if (wait_strategy_ != WaitStrategy::Blocking) return;
+
+  {
+    std::lock_guard<std::mutex> lock(work_ready_mutex_);
+    ++queued_entries_;
+  }
+  work_ready_cv_.notify_one();
+}
+
+void Logger::markEntryDequeued() {
+  if (wait_strategy_ != WaitStrategy::Blocking) return;
+
+  std::lock_guard<std::mutex> lock(work_ready_mutex_);
+  if (queued_entries_ > 0) --queued_entries_;
+}
+
+void Logger::waitForWork() {
+  std::unique_lock<std::mutex> lock(work_ready_mutex_);
+  work_ready_cv_.wait(lock, [this]() {
+    return !running_.load(std::memory_order_acquire) || queued_entries_ > 0;
+  });
+}
+
 void Logger::workerLoop() {
   Entry entry;
   while (running_) {
-    if (buffer_.tryPop(entry)) {
+    bool drained_entry = false;
+    while (buffer_.tryPop(entry)) {
+      markEntryDequeued();
       Logger::log(entry);
-    } else {
-      std::this_thread::yield();
+      drained_entry = true;
     }
+
+    if (!running_) break;
+    if (drained_entry) continue;
+
+    if (wait_strategy_ == WaitStrategy::Blocking)
+      waitForWork();
+    else
+      std::this_thread::yield();
   }
-  while (buffer_.tryPop(entry)) Logger::log(entry);
+  while (buffer_.tryPop(entry)) {
+    markEntryDequeued();
+    Logger::log(entry);
+  }
 }
 
 }  // namespace AsyncLogger

--- a/tests/async_logger_basic_test.cc
+++ b/tests/async_logger_basic_test.cc
@@ -51,3 +51,19 @@ TEST(AsyncLogger, ThreadSafety) {
   }
   std::remove(AsyncLoggerTest::kTempLog.c_str());
 }
+
+TEST(AsyncLogger, YieldingWaitStrategyStillLogsMessages) {
+  AsyncLogger::Config config;
+  config.level = AsyncLogger::Level::Info;
+  config.flag = AsyncLogger::OutstreamFlag::out_file;
+  config.filename = AsyncLoggerTest::kTempLog;
+  config.wait_strategy = AsyncLogger::WaitStrategy::Yielding;
+
+  AsyncLogger::Logger::init(config);
+  AsyncLogger::Logger::info("yielding strategy");
+  AsyncLogger::Logger::shutdown();
+
+  std::string content = AsyncLoggerTest::readFile(AsyncLoggerTest::kTempLog);
+  EXPECT_NE(content.find("yielding strategy"), std::string::npos);
+  std::remove(AsyncLoggerTest::kTempLog.c_str());
+}

--- a/tests/async_logger_file_test.cc
+++ b/tests/async_logger_file_test.cc
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <atomic>
 #include <ctime>
 #include <string>
 #include <thread>
@@ -8,6 +9,24 @@
 #include "async_logger_test_utils.h"
 
 namespace {
+std::atomic<int> g_timestamp_call_count{0};
+
+std::tm makeFixedTime(int sec) {
+  std::tm time{};
+  time.tm_year = 124;
+  time.tm_mon = 0;
+  time.tm_mday = 2;
+  time.tm_hour = 3;
+  time.tm_min = 4;
+  time.tm_sec = sec;
+  return time;
+}
+
+const std::tm sequencedTimeFunc() {
+  int call = g_timestamp_call_count.fetch_add(1, std::memory_order_relaxed);
+  return call == 0 ? makeFixedTime(5) : makeFixedTime(6);
+}
+
 const std::tm newTimeFunc() {
   std::tm time = AsyncLogger::LoggerUtils::getCurrentTime();
   time.tm_mday += 1;
@@ -76,6 +95,7 @@ TEST(AsyncLogger, TruncFileMode) {
 }
 
 TEST(AsyncLogger, LogFileRotation) {
+  AsyncLoggerTest::TimeFuncGuard time_guard;
   AsyncLogger::Logger::info("alpha");
   std::this_thread::sleep_for(std::chrono::milliseconds(500));
 
@@ -92,6 +112,29 @@ TEST(AsyncLogger, LogFileRotation) {
   content = AsyncLoggerTest::readFile(filename);
   EXPECT_NE(content.find("beta"), std::string::npos);
   std::remove(filename.c_str());
+}
+
+TEST(AsyncLogger, FileOutputUsesEnqueueTimestamp) {
+  AsyncLoggerTest::TimeFuncGuard time_guard;
+  g_timestamp_call_count.store(0, std::memory_order_relaxed);
+  AsyncLogger::LoggerUtils::timeFuncPtr = &sequencedTimeFunc;
+
+  AsyncLogger::Config config;
+  config.level = AsyncLogger::Level::Info;
+  config.flag = AsyncLogger::OutstreamFlag::out_file;
+  config.filename = AsyncLoggerTest::kTempLog;
+  config.wait_strategy = AsyncLogger::WaitStrategy::Blocking;
+
+  AsyncLogger::Logger::init(config);
+  AsyncLogger::Logger::info("captured timestamp");
+  AsyncLogger::Logger::shutdown();
+
+  std::string content = AsyncLoggerTest::readFile(AsyncLoggerTest::kTempLog);
+  EXPECT_NE(content.find(AsyncLoggerTest::formatTime(makeFixedTime(5))),
+            std::string::npos);
+  EXPECT_EQ(content.find(AsyncLoggerTest::formatTime(makeFixedTime(6))),
+            std::string::npos);
+  std::remove(AsyncLoggerTest::kTempLog.c_str());
 }
 
 TEST(AsyncLogger, FileOutputNeverContainsAnsiColorCodes) {

--- a/tests/async_logger_test_utils.h
+++ b/tests/async_logger_test_utils.h
@@ -1,8 +1,11 @@
 #pragma once
 
+#include <ctime>
 #include <fstream>
 #include <iterator>
 #include <string>
+
+#include "async_logger/async_logger.h"
 
 namespace AsyncLoggerTest {
 
@@ -13,5 +16,20 @@ inline std::string readFile(const std::string& filename) {
   return std::string((std::istreambuf_iterator<char>(ifs)),
                      std::istreambuf_iterator<char>());
 }
+
+inline std::string formatTime(const std::tm& tm) {
+  char time_buf[20];
+  std::strftime(time_buf, sizeof(time_buf), "%Y-%m-%d %H:%M:%S", &tm);
+  return time_buf;
+}
+
+class TimeFuncGuard {
+ public:
+  TimeFuncGuard() : old_(AsyncLogger::LoggerUtils::timeFuncPtr) {}
+  ~TimeFuncGuard() { AsyncLogger::LoggerUtils::timeFuncPtr = old_; }
+
+ private:
+  const std::tm (*old_)();
+};
 
 }  // namespace AsyncLoggerTest


### PR DESCRIPTION
## Summary
- capture each log entry timestamp at enqueue time instead of formatting time
- add configurable worker wait strategies with `Blocking` as the default and `Yielding` for low-latency use cases
- reset rotation state when reloading config so custom file outputs do not accidentally rotate back to the default daily file
- add regression coverage for enqueue-time timestamps and the yielding worker path

## Why
The logger previously stamped entries when the background worker formatted them, so queued logs could show the consumer thread's time rather than the caller's time. The worker also always used `yield()` when idle, which is wasteful for most applications but still useful as an opt-in path for latency-sensitive systems.

While implementing the new timestamp semantics, the test sequence also exposed a real state leak in file rotation setup: switching from a default daily log file to an explicit filename could leave rotation enabled from a previous initialization.

## Impact
Consumers now get timestamps that reflect when logging APIs were called. The default worker path blocks when idle to reduce CPU noise, and low-latency callers can still opt into the previous yielding behavior through `Config::wait_strategy`.

## Validation
- `cmake --build --preset debug`
- `ctest --preset debug -VV`
