### PR TITLE
Expose dropped-entry accounting for async logger

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -9,6 +9,20 @@ on:
     branches: [ "dev", "release" ]
 
 jobs:
+  format:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install clang-format
+      run: sudo apt-get update && sudo apt-get install -y clang-format
+
+    - name: Check formatting
+      run: >
+        clang-format --dry-run --Werror
+        $(git ls-files '*.cc' '*.h')
+
   build:
     runs-on: ${{ matrix.os }}
 

--- a/examples/async_logger_example.cc
+++ b/examples/async_logger_example.cc
@@ -1,6 +1,6 @@
 #include "async_logger/async_logger.h"
 
-int main(int argc, char *argv[]) {
+int main(int argc, char* argv[]) {
   AsyncLogger::Config config;
   config.filename = "test.log";
   config.level = AsyncLogger::Level::Debug;

--- a/examples/async_logger_macro_example.cc
+++ b/examples/async_logger_macro_example.cc
@@ -1,6 +1,6 @@
 #include "async_logger/async_logger_macro.h"
 
-int main(int argc, char *argv[]) {
+int main(int argc, char* argv[]) {
   LOG_INFO("hello from macro info log!");
   LOGF_INFO("hello from macro {} log!", "info");
   return 0;

--- a/include/async_logger/async_logger.h
+++ b/include/async_logger/async_logger.h
@@ -112,11 +112,13 @@ class Logger {
   // Thread and state related
   std::condition_variable work_ready_cv_;
   std::mutex work_ready_mutex_;
+  bool worker_waiting_{false};
   std::thread worker_;
   std::atomic<bool> running_{false};
 
   // Friend utils class
   friend class LoggerUtils;
+  friend class LoggerTestPeer;
 };
 
 class LoggerUtils {

--- a/include/async_logger/async_logger.h
+++ b/include/async_logger/async_logger.h
@@ -6,6 +6,7 @@
 #include <condition_variable>
 #include <ctime>
 #include <fstream>
+#include <memory>
 #include <mutex>
 #include <source_location>
 #include <stdexcept>
@@ -73,7 +74,7 @@ class Logger {
       const std::source_location& loc = std::source_location::current());
 
  private:
-  Logger() = default;
+  Logger();
   ~Logger();
   Logger(const Logger&) = delete;
   Logger& operator=(const Logger&) = delete;
@@ -105,14 +106,15 @@ class Logger {
   WaitStrategy wait_strategy_{WaitStrategy::Blocking};
 
   // Ring buffer for storing log entries
-  RingBuffer::MPSCRingBuffer<Entry> buffer_{1024};
+  static constexpr size_t kDefaultQueueCapacity = 1024;
+  size_t buffer_capacity_{kDefaultQueueCapacity};
+  std::unique_ptr<RingBuffer::MPSCRingBuffer<Entry>> buffer_;
   size_t queued_entries_{0};
   std::atomic<size_t> dropped_count_{0};
 
   // Thread and state related
   std::condition_variable work_ready_cv_;
   std::mutex work_ready_mutex_;
-  bool worker_waiting_{false};
   std::thread worker_;
   std::atomic<bool> running_{false};
 

--- a/include/async_logger/async_logger.h
+++ b/include/async_logger/async_logger.h
@@ -54,6 +54,8 @@ class Logger {
   static void init(const Config& config = Config());
   // Shutdown logger: stops worker and flushes remaining logs
   static void shutdown();
+  static size_t droppedCount();
+  static void resetStats();
 
   // Logging API
   static void debug(
@@ -84,6 +86,7 @@ class Logger {
   void notifyWorkerForEnqueuedEntry();
   void markEntryDequeued();
   void waitForWork();
+  void resetRuntimeState();
   static Logger& instance();
 
   // Initialize private method
@@ -104,6 +107,7 @@ class Logger {
   // Ring buffer for storing log entries
   RingBuffer::MPSCRingBuffer<Entry> buffer_{1024};
   size_t queued_entries_{0};
+  std::atomic<size_t> dropped_count_{0};
 
   // Thread and state related
   std::condition_variable work_ready_cv_;

--- a/src/async_logger.cc
+++ b/src/async_logger.cc
@@ -161,10 +161,7 @@ void Logger::init(const Config& config) {
   std::lock_guard<std::mutex> lock(lg.init_mutex_);
   if (lg.has_init_.load(std::memory_order_relaxed)) return;
 
-  {
-    std::lock_guard<std::mutex> work_lock(lg.work_ready_mutex_);
-    lg.queued_entries_ = 0;
-  }
+  lg.resetRuntimeState();
   lg.loadConfig(config);
 
   lg.running_ = true;
@@ -179,6 +176,7 @@ void Logger::ensureInit() {
   // slow path
   std::lock_guard<std::mutex> lock(init_mutex_);
   if (has_init_.load(std::memory_order_acquire)) return;
+  resetRuntimeState();
   loadConfig(Config());
   running_ = true;
   worker_ = std::thread(&Logger::workerLoop, this);
@@ -196,6 +194,14 @@ void Logger::shutdown() {
   }
   std::lock_guard<std::mutex> lock(lg.init_mutex_);
   lg.has_init_.store(false, std::memory_order_release);
+}
+
+size_t Logger::droppedCount() {
+  return instance().dropped_count_.load(std::memory_order_relaxed);
+}
+
+void Logger::resetStats() {
+  instance().dropped_count_.store(0, std::memory_order_relaxed);
 }
 
 void Logger::debug(const std::string& msg, const std::source_location& loc) {
@@ -236,8 +242,11 @@ Logger::~Logger() {
 void Logger::enqueue(Level lvl, const std::source_location& loc,
                      const std::string& msg) {
   if (lvl < level_.load(std::memory_order_relaxed)) return;
-  if (buffer_.tryPush({lvl, LoggerUtils::timeFuncPtr(), loc, msg}))
+  if (buffer_.tryPush({lvl, LoggerUtils::timeFuncPtr(), loc, msg})) {
     notifyWorkerForEnqueuedEntry();
+  } else {
+    dropped_count_.fetch_add(1, std::memory_order_relaxed);
+  }
 }
 
 std::string Logger::format(const Entry& entry, bool colored) {
@@ -289,6 +298,14 @@ void Logger::waitForWork() {
   work_ready_cv_.wait(lock, [this]() {
     return !running_.load(std::memory_order_acquire) || queued_entries_ > 0;
   });
+}
+
+void Logger::resetRuntimeState() {
+  {
+    std::lock_guard<std::mutex> work_lock(work_ready_mutex_);
+    queued_entries_ = 0;
+  }
+  dropped_count_.store(0, std::memory_order_relaxed);
 }
 
 void Logger::workerLoop() {

--- a/src/async_logger.cc
+++ b/src/async_logger.cc
@@ -42,6 +42,10 @@ void openFileOrThrow(std::ofstream& stream, const std::string& filename,
 FileOpenError::FileOpenError(const std::string& filename)
     : std::runtime_error("Failed to open file: " + filename) {}
 
+Logger::Logger()
+    : buffer_(std::make_unique<RingBuffer::MPSCRingBuffer<Entry>>(
+          kDefaultQueueCapacity)) {}
+
 const std::string_view LoggerUtils::getLevelString(Level lvl) {
   switch (lvl) {
     case Level::Debug:
@@ -242,7 +246,7 @@ Logger::~Logger() {
 void Logger::enqueue(Level lvl, const std::source_location& loc,
                      const std::string& msg) {
   if (lvl < level_.load(std::memory_order_relaxed)) return;
-  if (buffer_.tryPush({lvl, LoggerUtils::timeFuncPtr(), loc, msg})) {
+  if (buffer_->tryPush({lvl, LoggerUtils::timeFuncPtr(), loc, msg})) {
     notifyWorkerForEnqueuedEntry();
   } else {
     dropped_count_.fetch_add(1, std::memory_order_relaxed);
@@ -295,18 +299,17 @@ void Logger::markEntryDequeued() {
 
 void Logger::waitForWork() {
   std::unique_lock<std::mutex> lock(work_ready_mutex_);
-  worker_waiting_ = true;
   work_ready_cv_.wait(lock, [this]() {
     return !running_.load(std::memory_order_acquire) || queued_entries_ > 0;
   });
-  worker_waiting_ = false;
 }
 
 void Logger::resetRuntimeState() {
+  buffer_ =
+      std::make_unique<RingBuffer::MPSCRingBuffer<Entry>>(buffer_capacity_);
   {
     std::lock_guard<std::mutex> work_lock(work_ready_mutex_);
     queued_entries_ = 0;
-    worker_waiting_ = false;
   }
   dropped_count_.store(0, std::memory_order_relaxed);
 }
@@ -315,7 +318,7 @@ void Logger::workerLoop() {
   Entry entry;
   while (running_) {
     bool drained_entry = false;
-    while (buffer_.tryPop(entry)) {
+    while (buffer_->tryPop(entry)) {
       markEntryDequeued();
       Logger::log(entry);
       drained_entry = true;
@@ -329,7 +332,7 @@ void Logger::workerLoop() {
     else
       std::this_thread::yield();
   }
-  while (buffer_.tryPop(entry)) {
+  while (buffer_->tryPop(entry)) {
     markEntryDequeued();
     Logger::log(entry);
   }

--- a/src/async_logger.cc
+++ b/src/async_logger.cc
@@ -295,15 +295,18 @@ void Logger::markEntryDequeued() {
 
 void Logger::waitForWork() {
   std::unique_lock<std::mutex> lock(work_ready_mutex_);
+  worker_waiting_ = true;
   work_ready_cv_.wait(lock, [this]() {
     return !running_.load(std::memory_order_acquire) || queued_entries_ > 0;
   });
+  worker_waiting_ = false;
 }
 
 void Logger::resetRuntimeState() {
   {
     std::lock_guard<std::mutex> work_lock(work_ready_mutex_);
     queued_entries_ = 0;
+    worker_waiting_ = false;
   }
   dropped_count_.store(0, std::memory_order_relaxed);
 }

--- a/tests/async_logger_basic_test.cc
+++ b/tests/async_logger_basic_test.cc
@@ -6,6 +6,23 @@
 #include "async_logger/async_logger.h"
 #include "async_logger_test_utils.h"
 
+namespace {
+
+void emitBurstLogs(int thread_count, int messages_per_thread) {
+  std::vector<std::thread> threads;
+  threads.reserve(thread_count);
+  for (int i = 0; i < thread_count; ++i) {
+    threads.emplace_back([messages_per_thread]() {
+      for (int j = 0; j < messages_per_thread; ++j) {
+        AsyncLogger::Logger::info("dropped message");
+      }
+    });
+  }
+  for (auto& th : threads) th.join();
+}
+
+}  // namespace
+
 TEST(AsyncLogger, LevelFiltering) {
   // Init with level WARN, debug/info should be filtered out
   AsyncLogger::Config config;
@@ -78,15 +95,7 @@ TEST(AsyncLogger, DroppedCountStartsAtZeroAndCanBeReset) {
   AsyncLogger::Logger::init(config);
   EXPECT_EQ(AsyncLogger::Logger::droppedCount(), 0u);
 
-  std::vector<std::thread> threads;
-  for (int i = 0; i < 8; ++i) {
-    threads.emplace_back([]() {
-      for (int j = 0; j < 256; ++j) {
-        AsyncLogger::Logger::info("dropped message");
-      }
-    });
-  }
-  for (auto& th : threads) th.join();
+  emitBurstLogs(32, 4096);
   AsyncLogger::Logger::shutdown();
 
   EXPECT_GT(AsyncLogger::Logger::droppedCount(), 0u);
@@ -104,15 +113,7 @@ TEST(AsyncLogger, DroppedCountResetsOnReinit) {
   config.filename = AsyncLoggerTest::kTempLog;
 
   AsyncLogger::Logger::init(config);
-  std::vector<std::thread> threads;
-  for (int i = 0; i < 8; ++i) {
-    threads.emplace_back([]() {
-      for (int j = 0; j < 256; ++j) {
-        AsyncLogger::Logger::info("dropped message");
-      }
-    });
-  }
-  for (auto& th : threads) th.join();
+  emitBurstLogs(32, 4096);
   AsyncLogger::Logger::shutdown();
   ASSERT_GT(AsyncLogger::Logger::droppedCount(), 0u);
 

--- a/tests/async_logger_basic_test.cc
+++ b/tests/async_logger_basic_test.cc
@@ -67,3 +67,42 @@ TEST(AsyncLogger, YieldingWaitStrategyStillLogsMessages) {
   EXPECT_NE(content.find("yielding strategy"), std::string::npos);
   std::remove(AsyncLoggerTest::kTempLog.c_str());
 }
+
+TEST(AsyncLogger, DroppedCountStartsAtZeroAndCanBeReset) {
+  AsyncLogger::Config config;
+  config.level = AsyncLogger::Level::Info;
+  config.flag = AsyncLogger::OutstreamFlag::out_file;
+  config.filename = AsyncLoggerTest::kTempLog;
+
+  AsyncLogger::Logger::init(config);
+  EXPECT_EQ(AsyncLogger::Logger::droppedCount(), 0u);
+
+  ASSERT_TRUE(AsyncLogger::LoggerTestPeer::waitUntilWorkerIsWaiting());
+  AsyncLogger::LoggerTestPeer::fillBufferToCapacity();
+  AsyncLogger::Logger::info("dropped message");
+  AsyncLogger::Logger::shutdown();
+
+  EXPECT_GT(AsyncLogger::Logger::droppedCount(), 0u);
+  AsyncLogger::Logger::resetStats();
+  EXPECT_EQ(AsyncLogger::Logger::droppedCount(), 0u);
+  std::remove(AsyncLoggerTest::kTempLog.c_str());
+}
+
+TEST(AsyncLogger, DroppedCountResetsOnReinit) {
+  AsyncLogger::Config config;
+  config.level = AsyncLogger::Level::Info;
+  config.flag = AsyncLogger::OutstreamFlag::out_file;
+  config.filename = AsyncLoggerTest::kTempLog;
+
+  AsyncLogger::Logger::init(config);
+  ASSERT_TRUE(AsyncLogger::LoggerTestPeer::waitUntilWorkerIsWaiting());
+  AsyncLogger::LoggerTestPeer::fillBufferToCapacity();
+  AsyncLogger::Logger::info("dropped message");
+  AsyncLogger::Logger::shutdown();
+  ASSERT_GT(AsyncLogger::Logger::droppedCount(), 0u);
+
+  AsyncLogger::Logger::init(config);
+  EXPECT_EQ(AsyncLogger::Logger::droppedCount(), 0u);
+  AsyncLogger::Logger::shutdown();
+  std::remove(AsyncLoggerTest::kTempLog.c_str());
+}

--- a/tests/async_logger_basic_test.cc
+++ b/tests/async_logger_basic_test.cc
@@ -69,6 +69,7 @@ TEST(AsyncLogger, YieldingWaitStrategyStillLogsMessages) {
 }
 
 TEST(AsyncLogger, DroppedCountStartsAtZeroAndCanBeReset) {
+  AsyncLogger::LoggerTestPeer::setBufferCapacity(1);
   AsyncLogger::Config config;
   config.level = AsyncLogger::Level::Info;
   config.flag = AsyncLogger::OutstreamFlag::out_file;
@@ -77,32 +78,47 @@ TEST(AsyncLogger, DroppedCountStartsAtZeroAndCanBeReset) {
   AsyncLogger::Logger::init(config);
   EXPECT_EQ(AsyncLogger::Logger::droppedCount(), 0u);
 
-  ASSERT_TRUE(AsyncLogger::LoggerTestPeer::waitUntilWorkerIsWaiting());
-  AsyncLogger::LoggerTestPeer::fillBufferToCapacity();
-  AsyncLogger::Logger::info("dropped message");
+  std::vector<std::thread> threads;
+  for (int i = 0; i < 8; ++i) {
+    threads.emplace_back([]() {
+      for (int j = 0; j < 256; ++j) {
+        AsyncLogger::Logger::info("dropped message");
+      }
+    });
+  }
+  for (auto& th : threads) th.join();
   AsyncLogger::Logger::shutdown();
 
   EXPECT_GT(AsyncLogger::Logger::droppedCount(), 0u);
   AsyncLogger::Logger::resetStats();
   EXPECT_EQ(AsyncLogger::Logger::droppedCount(), 0u);
+  AsyncLogger::LoggerTestPeer::resetBufferCapacity();
   std::remove(AsyncLoggerTest::kTempLog.c_str());
 }
 
 TEST(AsyncLogger, DroppedCountResetsOnReinit) {
+  AsyncLogger::LoggerTestPeer::setBufferCapacity(1);
   AsyncLogger::Config config;
   config.level = AsyncLogger::Level::Info;
   config.flag = AsyncLogger::OutstreamFlag::out_file;
   config.filename = AsyncLoggerTest::kTempLog;
 
   AsyncLogger::Logger::init(config);
-  ASSERT_TRUE(AsyncLogger::LoggerTestPeer::waitUntilWorkerIsWaiting());
-  AsyncLogger::LoggerTestPeer::fillBufferToCapacity();
-  AsyncLogger::Logger::info("dropped message");
+  std::vector<std::thread> threads;
+  for (int i = 0; i < 8; ++i) {
+    threads.emplace_back([]() {
+      for (int j = 0; j < 256; ++j) {
+        AsyncLogger::Logger::info("dropped message");
+      }
+    });
+  }
+  for (auto& th : threads) th.join();
   AsyncLogger::Logger::shutdown();
   ASSERT_GT(AsyncLogger::Logger::droppedCount(), 0u);
 
   AsyncLogger::Logger::init(config);
   EXPECT_EQ(AsyncLogger::Logger::droppedCount(), 0u);
   AsyncLogger::Logger::shutdown();
+  AsyncLogger::LoggerTestPeer::resetBufferCapacity();
   std::remove(AsyncLoggerTest::kTempLog.c_str());
 }

--- a/tests/async_logger_test_utils.h
+++ b/tests/async_logger_test_utils.h
@@ -1,11 +1,9 @@
 #pragma once
 
-#include <chrono>
 #include <ctime>
 #include <fstream>
 #include <iterator>
 #include <string>
-#include <thread>
 
 #include "async_logger/async_logger.h"
 
@@ -40,24 +38,14 @@ namespace AsyncLogger {
 
 class LoggerTestPeer {
  public:
-  static bool waitUntilWorkerIsWaiting() {
+  static void setBufferCapacity(size_t capacity) {
     auto& logger = Logger::instance();
-    for (int i = 0; i < 1000; ++i) {
-      {
-        std::lock_guard<std::mutex> lock(logger.work_ready_mutex_);
-        if (logger.worker_waiting_) return true;
-      }
-      std::this_thread::sleep_for(std::chrono::milliseconds(1));
-    }
-    return false;
+    logger.buffer_capacity_ = capacity;
   }
 
-  static void fillBufferToCapacity() {
+  static void resetBufferCapacity() {
     auto& logger = Logger::instance();
-    Entry entry{Level::Info, LoggerUtils::getCurrentTime(),
-                std::source_location::current(), "prefill"};
-    while (logger.buffer_.tryPush(entry)) {
-    }
+    logger.buffer_capacity_ = Logger::kDefaultQueueCapacity;
   }
 };
 

--- a/tests/async_logger_test_utils.h
+++ b/tests/async_logger_test_utils.h
@@ -1,9 +1,11 @@
 #pragma once
 
+#include <chrono>
 #include <ctime>
 #include <fstream>
 #include <iterator>
 #include <string>
+#include <thread>
 
 #include "async_logger/async_logger.h"
 
@@ -33,3 +35,30 @@ class TimeFuncGuard {
 };
 
 }  // namespace AsyncLoggerTest
+
+namespace AsyncLogger {
+
+class LoggerTestPeer {
+ public:
+  static bool waitUntilWorkerIsWaiting() {
+    auto& logger = Logger::instance();
+    for (int i = 0; i < 1000; ++i) {
+      {
+        std::lock_guard<std::mutex> lock(logger.work_ready_mutex_);
+        if (logger.worker_waiting_) return true;
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    return false;
+  }
+
+  static void fillBufferToCapacity() {
+    auto& logger = Logger::instance();
+    Entry entry{Level::Info, LoggerUtils::getCurrentTime(),
+                std::source_location::current(), "prefill"};
+    while (logger.buffer_.tryPush(entry)) {
+    }
+  }
+};
+
+}  // namespace AsyncLogger


### PR DESCRIPTION
## Summary
- expose dropped-entry accounting through `Logger::droppedCount()` and `Logger::resetStats()`
- increment the dropped counter when the async ring buffer rejects a log entry
- add regression coverage for dropped-entry stats, including reset and re-init semantics

## Why
The logger previously ignored `buffer_.tryPush(...)` failures, which meant messages could be dropped silently under pressure with no visibility for callers. This change keeps the existing non-blocking behavior, but makes loss observable so applications and tests can detect it.

## Impact
Consumers can now query how many log entries were dropped during the current logger lifetime. The implementation does not introduce fallback writes or producer-side blocking.

## Validation
- `cmake --build --preset debug`
- `ctest --preset debug -VV`
